### PR TITLE
update elastigo, use fix for POST mime-type

### DIFF
--- a/Goopfile
+++ b/Goopfile
@@ -1,1 +1,1 @@
-github.com/mattbaird/elastigo
+github.com/liquidm/elastigo

--- a/Goopfile.lock
+++ b/Goopfile.lock
@@ -1,3 +1,3 @@
 github.com/araddon/gou #cf9cf25f52be174c5878920a8021bd224cbe32c7
 github.com/bitly/go-hostpool #d0e59c22a56e8dadfed24f74f452cea5a52722d2
-github.com/liquidm/elastigo #2fe47fd29e4b70353f852ede77a196830d2924ec
+github.com/liquidm/elastigo #0de2d0be8317018954f25a99460dc2de2b051968

--- a/Goopfile.lock
+++ b/Goopfile.lock
@@ -1,3 +1,3 @@
 github.com/araddon/gou #cf9cf25f52be174c5878920a8021bd224cbe32c7
 github.com/bitly/go-hostpool #d0e59c22a56e8dadfed24f74f452cea5a52722d2
-github.com/mattbaird/elastigo #a0300cf10e1a98c02243f5acf9bd94099aca09e5
+github.com/mattbaird/elastigo #2fe47fd29e4b70353f852ede77a196830d2924ec

--- a/Goopfile.lock
+++ b/Goopfile.lock
@@ -1,3 +1,3 @@
 github.com/araddon/gou #cf9cf25f52be174c5878920a8021bd224cbe32c7
 github.com/bitly/go-hostpool #d0e59c22a56e8dadfed24f74f452cea5a52722d2
-github.com/mattbaird/elastigo #2fe47fd29e4b70353f852ede77a196830d2924ec
+github.com/liquidm/elastigo #2fe47fd29e4b70353f852ede77a196830d2924ec

--- a/service.go
+++ b/service.go
@@ -145,10 +145,11 @@ func (s *Service) ProcessEntry(hostname *string) {
 		indexName,       // index
 		"journal",       // type
 		cursorId,        // id
+		"",              // parent
 		"",              // ttl
 		nil,             // date
 		string(message), // content
-		false)           // immediate index refresh
+	)
 }
 
 func (s *Service) ProcessEntryFields(row map[string]interface{}) {

--- a/service.go
+++ b/service.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/mattbaird/elastigo/lib"
+	"github.com/liquidm/elastigo/lib"
 )
 
 // #include <stdio.h>


### PR DESCRIPTION
https://trello.com/c/U4KTIY0v/1877-elastic-journald-content-type-detection-for-rest-requests-is-deprecated